### PR TITLE
VersionMap must contain all structs at their current versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.1.2
+
+- Added a safety check for enforcing that the VersionMaps provided for
+  (de)serialization are up-to-date with the latest versions of the
+  structs/enums/unions.
+
 # v0.1.1
 
 - Removed "versionize" dependency.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "versionize_derive"
-version = "0.1.1"
+version = "0.1.2"
 license = "Apache-2.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 description = "Implements the Versionize derive proc macro."

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -3,7 +3,7 @@
 
 use super::{ATTRIBUTE_NAME, END_VERSION, START_VERSION};
 use common::Exists;
-use quote::format_ident;
+use quote::{format_ident, quote};
 use std::cmp::max;
 use std::collections::hash_map::HashMap;
 
@@ -76,6 +76,18 @@ pub fn is_array(ty: &syn::Type) -> bool {
     match ty {
         syn::Type::Array(_) => true,
         _ => false,
+    }
+}
+
+// Enforce that the latest VersionMap version is up-to-date with the latest
+// struct/enum/union version.
+pub(crate) fn latest_version_check(current_version: u16) -> proc_macro2::TokenStream {
+    quote! {
+        // Get the struct version for the input app_version.
+        let version = version_map.get_type_version(app_version, <Self as Versionize>::type_id());
+        if app_version == version_map.latest_version() && version != #current_version {
+            return Err(VersionizeError::VersionMapNotUpdated);
+        }
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Ioana Chirca <chioana@amazon.com>

If we are (de)serializing at the latest version from VersionMap, check that the struct's current version matches the version from the map. If it doesn't, it means that the Version Map is outdated.

Running `cargo bench` in `firecracker/src/snapshot` crate after updating the `versionize_derive` dependency gives us these mean times:

| Test                |      Mean     |
|---------------------|---------------|
| Serialize           |    320.47 us  |
| Serialize + crc64   |    378.65 us  |
| Deserialize         |    59.05 us  |
| Deserialize + crc64 |    224.21 us  |

The extra checks do not introduce a regression (current baseline [here](https://github.com/firecracker-microvm/firecracker/blob/master/docs/benchmarks/state-serialize.md))

## Description of Changes

- add a check for outdated Version Map
- bump the crate version (the check requires `VersionizeError` to be in scope, which is not necessarily true for the crates using `versionize_derive`)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
