### PR TITLE
Versionize enum variant with >=0 fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.1.1
+
+- Removed "versionize" dependency.
+- Added support for (de)serializing enum variants with zero or more fields.
+
 # v0.1.0
 
 - "versionize_derive" v0.1.0 first release.

--- a/src/fields/enum_variant.rs
+++ b/src/fields/enum_variant.rs
@@ -63,7 +63,7 @@ impl EnumVariant {
         if !self.exists_at(target_version) {
             if let Some(default_fn_ident) = get_ident_attr(&self.attrs, DEFAULT_FN) {
                 return quote! {
-                    Self::#field_ident(_) => {
+                    Self::#field_ident(..) => {
                         // Call user defined fn to provide a variant that exists in target version.
                         let new_variant = self.#default_fn_ident(version)?;
                         // The new_variant will serialize it's index and data.


### PR DESCRIPTION
Signed-off-by: Ioana Chirca <chioana@amazon.com>

## Reason for This PR

This PR adds support for versionizing an enum variant with zero or more fields.

Example:
```
#[derive(Versionize)]
pub enum X {
    One,
    #[version(start = 2, default_fn = "default")]
    Two(u32, u64),
    #[version(start = 3, default_fn = "default")]
    Three,
}
```

Fixes https://github.com/firecracker-microvm/firecracker/issues/1788 and https://github.com/firecracker-microvm/firecracker/issues/1787

## Description of Changes

`[Author TODO: add description of changes.]`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
