### PR TITLE
Update rust-vmm-ci to neweset version

### DIFF
--- a/src/descriptors/struct_desc.rs
+++ b/src/descriptors/struct_desc.rs
@@ -107,7 +107,7 @@ impl StructDescriptor {
         match fields {
             syn::Fields::Named(ref named_fields) => {
                 let pairs = named_fields.named.pairs();
-                for field in pairs.into_iter() {
+                for field in pairs {
                     self.fields.push(StructField::new(self.version, field));
                 }
             }

--- a/src/fields/enum_variant.rs
+++ b/src/fields/enum_variant.rs
@@ -31,18 +31,15 @@ impl Exists for EnumVariant {
 impl EnumVariant {
     pub fn new(base_version: u16, ast_variant: &syn::Variant, variant_index: u32) -> Self {
         let attrs = parse_field_attributes(&ast_variant.attrs);
-        let ty;
 
-        match &ast_variant.fields {
-            syn::Fields::Unnamed(fields) => {
-                ty = fields
-                    .unnamed
-                    .iter()
-                    .map(|field| field.ty.clone())
-                    .collect();
-            }
-            _ => ty = Vec::new(),
-        }
+        let ty = match &ast_variant.fields {
+            syn::Fields::Unnamed(fields) => fields
+                .unnamed
+                .iter()
+                .map(|field| field.ty.clone())
+                .collect(),
+            _ => Vec::new(),
+        };
 
         EnumVariant {
             ident: ast_variant.ident.clone(),
@@ -73,7 +70,7 @@ impl EnumVariant {
                 serializer.extend(self.default_fn_serializer(default_fn_ident));
                 return serializer;
             } else {
-                panic!("Variant {} does not exist in version {}, please implement a default_fn function that provides a default value for this variant.", field_ident.to_string(), target_version);
+                panic!("Variant {} does not exist in version {}, please implement a default_fn function that provides a default value for this variant.", field_ident, target_version);
             }
         }
 
@@ -131,12 +128,12 @@ impl EnumVariant {
             );
         }
 
-        return quote! {
+        quote! {
             #variant_index => {
                 #deserialize_data
                 return Ok(Self::#ident(#data_tuple));
             },
-        };
+        }
     }
 
     fn default_fn_serializer(&self, default_fn_ident: syn::Ident) -> proc_macro2::TokenStream {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -14,7 +14,7 @@ pub(crate) fn get_ident_attr(
 ) -> Option<syn::Ident> {
     attrs.get(attr_name).map(|default_fn| match default_fn {
         syn::Lit::Str(lit_str) => {
-            return format_ident!("{}", lit_str.value());
+            format_ident!("{}", lit_str.value())
         }
         _ => panic!("default_fn must be the function name as a String."),
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! - Versionize trait implementations for repr(C) unions must be backed by
 //! extensive testing.
 //! - Semantic serialization and deserialization is available only for structures.
-//!
+
 extern crate proc_macro;
 extern crate proc_macro2;
 extern crate quote;
@@ -217,9 +217,9 @@ pub fn impl_versionize(input: TokenStream) -> proc_macro::TokenStream {
 
     let descriptor: Box<dyn Descriptor> = match &input.data {
         syn::Data::Struct(data_struct) => {
-            Box::new(StructDescriptor::new(&data_struct, ident.clone()))
+            Box::new(StructDescriptor::new(data_struct, ident.clone()))
         }
-        syn::Data::Enum(data_enum) => Box::new(EnumDescriptor::new(&data_enum, ident.clone())),
+        syn::Data::Enum(data_enum) => Box::new(EnumDescriptor::new(data_enum, ident.clone())),
         syn::Data::Union(_) => {
             return (quote! {
                 compile_error!("Union serialization is not supported.");


### PR DESCRIPTION
## Reason for This PR

We need to pick up an increase in the default timeout due to an epoll_wait regression in linux. 

## Description of Changes

update submodule and fix new clippy warnings

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
