### PR TITLE
Build: bump crate version to 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.1.5
+
+- Ping dependency versions
+- Fix clippy errors and warnings
+- Bump rust-vmm-ci version
+
 # v0.1.4
 
 - Added more documentation and examples.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "versionize_derive"
-version = "0.1.4"
+version = "0.1.5"
 license = "Apache-2.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 description = "Implements the Versionize derive proc macro."


### PR DESCRIPTION
## Reason for This PR

This new version ensures all dependencies are pinged to a specific version. This is required for the consumers of the crate to build correctly, such as the `versionize` crate.

## Description of Changes

Bump crate version to 0.1.5 with corresponding changes to the `https://changelog.md/`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist
- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
