### PR TITLE
Allow array lengths to be any expression.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.6
+
+- Allow array length definitions to include casts and other expressions
+
 # v0.1.5
 
 - Ping dependency versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "versionize_derive"
-version = "0.1.5"
+version = "0.1.6"
 license = "Apache-2.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 description = "Implements the Versionize derive proc macro."

--- a/src/fields/struct_field.rs
+++ b/src/fields/struct_field.rs
@@ -127,19 +127,7 @@ impl StructField {
                     _ => panic!("Unsupported array type."),
                 }
 
-                match &array.len {
-                    syn::Expr::Lit(expr_lit) => match &expr_lit.lit {
-                        syn::Lit::Int(lit_int) => {
-                            let array_len: usize = lit_int.base10_parse().unwrap();
-                            self.generate_array_deserializer(array_type_token, array_len)
-                        }
-                        _ => panic!("Unsupported array len literal."),
-                    },
-                    syn::Expr::Path(expr_path) => {
-                        self.generate_array_deserializer(array_type_token, &expr_path.path)
-                    }
-                    _ => panic!("Unsupported array len expression."),
-                }
+                self.generate_array_deserializer(array_type_token, &array.len)
             }
             syn::Type::Path(_) => quote! {
                 #field_ident: <#ty as Versionize>::deserialize(&mut reader, version_map, app_version)?,
@@ -151,10 +139,10 @@ impl StructField {
         }
     }
 
-    fn generate_array_deserializer<T: quote::ToTokens>(
+    fn generate_array_deserializer(
         &self,
         array_type_token: syn::TypePath,
-        array_len: T,
+        array_len: &syn::Expr,
     ) -> proc_macro2::TokenStream {
         let field_ident = format_ident!("{}", self.name);
 


### PR DESCRIPTION
## Reason for This PR

As part of https://github.com/firecracker-microvm/firecracker/pull/3557#issuecomment-1686610219, I'd like to change the types of some of the size constants currently used as array length expressions from `usize` to fixed-size types like `u8` or `u16`. Rust needs these to be explicitly casted to `usize` when they're used, but that causes an error with `#[derive(Versionize)]` because the size currently needs to be either a literal value or a constant.

## Description of Changes

This PR changes the size field to accept any expression that's valid in an array size expression to also be accepted by `#[derive(Versionize)]`.

Tests have been added to the main `versionize` repository in https://github.com/firecracker-microvm/versionize/pull/60.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
